### PR TITLE
Configure symfony to use the database for session-storage.

### DIFF
--- a/app/DoctrineMigrations/Version20190206085935.php
+++ b/app/DoctrineMigrations/Version20190206085935.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20190206085935 extends AbstractMigration
+{
+  /**
+   * @param Schema $schema
+   */
+  public function up(Schema $schema)
+  {
+    // this up() migration is auto-generated, please modify it to your needs
+    $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+    $this->addSql('CREATE TABLE php_sessions (sess_id VARCHAR(128) NOT NULL PRIMARY KEY, sess_data BLOB NOT NULL, sess_time INTEGER UNSIGNED NOT NULL, sess_lifetime MEDIUMINT NOT NULL) COLLATE utf8_bin, ENGINE = InnoDB');
+
+  }
+
+  /**
+   * @param Schema $schema
+   */
+  public function down(Schema $schema)
+  {
+    // this down() migration is auto-generated, please modify it to your needs
+    $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+    $this->addSql('DROP TABLE php_sessions');
+  }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,10 +19,19 @@ framework:
   trusted_hosts:   ~
   trusted_proxies: ~
   session:
-    handler_id:  ~
+    handler_id:  session.handler.pdo
     cookie_lifetime: 0
   fragments:       ~
   http_method_override: true
+
+services:
+  session.handler.pdo:
+    class:     Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
+    public:    false
+    arguments:
+      - 'mysql:host=%database_host%;dbname=%database_name%'
+      - { db_table: 'php_sessions', db_username: '%database_user%', db_password: '%database_password%' }
+
 
 # Twig Configuration
 twig:


### PR DESCRIPTION
This way the sessions will survive the situation where we clear the non-app file-
system between deployments.