### PR TITLE
Use gulp-sass compiler and downgrade to node 8.

### DIFF
--- a/src/kkos2-display-bundle/gulpfile.js
+++ b/src/kkos2-display-bundle/gulpfile.js
@@ -7,9 +7,7 @@ const gulp = require("gulp");
 const concat = require("gulp-concat");
 const uglify = require("gulp-uglify");
 const rename = require("gulp-rename");
-var sass = require('gulp-sass');
-// Explicitly set the node-sass compiler.
-sass.compiler = require('node-sass');
+const sass = require('gulp-sass');
 
 /**
  * Get an array of dir names in a dir.
@@ -18,7 +16,7 @@ sass.compiler = require('node-sass');
  * @returns {string[]} Array of strings with directory names.
  */
 const dirsInDir = source => fs.readdirSync(source, {withFileTypes: true})
-  .filter(c => c.isDirectory()).map(c => c.name);
+  .filter(c => fs.statSync(source + '/' + c).isDirectory());
 
 const scssDir = "Resources/public/assets/scss";
 const slidesPath = "Resources/public/templates/slides";

--- a/src/kkos2-display-bundle/package.json
+++ b/src/kkos2-display-bundle/package.json
@@ -13,5 +13,8 @@
   },
   "scripts": {
     "gulp": "gulp"
+  },
+  "engines": {
+    "node": "8.x"
   }
 }


### PR DESCRIPTION
We need to make use of the node version that we get distrubuted via
our image.
Besides that there were some code that was not compatible with node v8.